### PR TITLE
Add Graphite Webapp

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ graphite_install_path: "/opt/graphite"
 graphite_pip_packages:
   - "carbon=={{ graphite_version }}"
   - "whisper=={{ graphite_version }}"
+  - "graphite-web=={{ graphite_version }}"
 
 graphite_search_config_path: "{{ playbook_dir }}/files/groups/{{ item }}/graphite"
 graphite_search_config_paths: []

--- a/tasks/graphite_install.yml
+++ b/tasks/graphite_install.yml
@@ -1,10 +1,13 @@
 ---
-- name: Install pip 
+- name: Install apt dependencies 
   apt:
     name: "{{ item }}"
     state: present
     update_cache: yes
   with_items: "{{ graphite_apt_packages }}"
+
+- name: Install pip
+  command: python /tmp/get-pip.py
 
 - name: Install Graphite with pip
   pip:
@@ -13,3 +16,4 @@
   environment:
     PYTHONPATH: "{{ graphite_install_path }}/lib:{{ graphite_install_path }}/webapp"
   with_items: "{{ graphite_pip_packages }}"
+  notify: Restart Graphite

--- a/tasks/graphite_post.yml
+++ b/tasks/graphite_post.yml
@@ -1,12 +1,4 @@
 ---
-- name: Set permission for Graphite
-  file:
-    path: "{{ graphite_install_path }}"
-    owner: "{{ graphite_user }}"
-    group: "{{ graphite_group }}"
-    recurse: yes
-    state: directory
-
 - name: Copy Graphite configuration file
   template:
     src: "{{ graphite_host_config_file_path }}"
@@ -21,7 +13,30 @@
   template:
     src: storage-schemas.conf.j2
     dest: "{{ graphite_install_path }}/conf/storage-schemas.conf"
+    owner: "{{ graphite_user }}"
+    group: "{{ graphite_group }}"
   notify: Restart Graphite
+
+- name: Copy WSGI config
+  copy: 
+    src:  "{{ graphite_install_path }}/conf/graphite.wsgi.example"
+    dest: "{{ graphite_install_path }}/conf/wsgi.py"
+    owner: "{{ graphite_user }}"
+    group: "{{ graphite_group }}"
+    remote_src: true
+
+- name: Run Graphite webapp migration
+  command: "django-admin.py migrate --settings=graphite.settings --run-syncdb"
+  environment:
+    PYTHONPATH: "{{ graphite_install_path }}/webapp"
+
+- name: Set permission for Graphite
+  file:
+    path: "{{ graphite_install_path }}"
+    owner: "{{ graphite_user }}"
+    group: "{{ graphite_group }}"
+    recurse: yes
+    state: directory
 
 - name: Create systemd unit file
   template:
@@ -34,3 +49,8 @@
     state: started
     enabled: yes
     daemon_reload: yes
+
+- name: Delete pip install script
+  file: 
+    path: /tmp/get-pip.py
+    state: absent

--- a/tasks/graphite_pre.yml
+++ b/tasks/graphite_pre.yml
@@ -1,10 +1,15 @@
 ---
-  - name: Add Graphite group
-    group:
-      name: "{{ graphite_group }}"
+- name: Add Graphite group
+  group:
+    name: "{{ graphite_group }}"
 
-  - name: Add Graphite user
-    user:
-      name: "{{ graphite_user }}"
-      group: "{{ graphite_group }}"
-      shell: /bin/bash
+- name: Add Graphite user
+  user:
+    name: "{{ graphite_user }}"
+    group: "{{ graphite_group }}"
+    shell: /bin/bash
+
+- name: Download pip install script from pypa
+  get_url: 
+    url: https://bootstrap.pypa.io/get-pip.py
+    dest: /tmp

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,6 @@
 ---
 graphite_apt_packages:
   - python-dev
-  - python-pip
   - libcairo2-dev
   - libffi-dev
   - build-essential


### PR DESCRIPTION
## Improvement
- Add graphite webapp package & migration script
- Add pip install script instead of install via apt package

## Refactor
- Move set permission for graphite folder after webapp migration
- Add restart handlers when install pip package
- Some styling changes
